### PR TITLE
OES-47 and OES-48: Import KML and KMZ with default refresh rate

### DIFF
--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/DatalayerService.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/DatalayerService.java
@@ -97,7 +97,7 @@ public interface DatalayerService {
 			@PathParam("workspaceId") int workspaceId,
 			@PathParam("dataSourceId") String dataSourceId,
 			@PathParam("userOrgId") int userOrgId,
-			@DefaultValue("300") @Multipart(value = "refreshrate", required = false) int refreshRate,
+			@DefaultValue("300") @Multipart(value = "refreshrate", required = false) String refreshRate,
 			MultipartBody body,
 			@HeaderParam("CUSTOM-uid") String username);
 	

--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/DatalayerService.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/DatalayerService.java
@@ -29,15 +29,7 @@
  */
 package edu.mit.ll.em.api.rs;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -105,7 +97,7 @@ public interface DatalayerService {
 			@PathParam("workspaceId") int workspaceId,
 			@PathParam("dataSourceId") String dataSourceId,
 			@PathParam("userOrgId") int userOrgId,
-			@Multipart(value = "refreshrate", required = false) int refreshRate,
+			@DefaultValue("300") @Multipart(value = "refreshrate", required = false) int refreshRate,
 			MultipartBody body,
 			@HeaderParam("CUSTOM-uid") String username);
 	

--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/DatalayerServiceImpl.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/DatalayerServiceImpl.java
@@ -463,8 +463,8 @@ public class DatalayerServiceImpl implements DatalayerService {
 		return Response.ok(datalayerResponse).status(Status.OK).build();
 	}
 	
-	public Response postDataLayerDocument(int workspaceId, String fileExt, int userOrgId, int refreshRate, MultipartBody body, String username){
-		
+	public Response postDataLayerDocument(int workspaceId, String fileExt, int userOrgId, String refreshRate, MultipartBody body, String username){
+		int numericRefreshRate = parseRefreshRate(refreshRate);
 		DatalayerDocumentServiceResponse datalayerResponse = new DatalayerDocumentServiceResponse();
 		Response response = null;
 		Datalayerfolder newDatalayerFolder = null;
@@ -545,7 +545,7 @@ public class DatalayerServiceImpl implements DatalayerService {
 					datalayer.setCreated(new Date());
 					datalayer.getDatalayersource().setCreated(new Date());
 					datalayer.getDatalayersource().setDatasourceid(dataSourceId);
-					datalayer.getDatalayersource().setRefreshrate(refreshRate);
+					datalayer.getDatalayersource().setRefreshrate(numericRefreshRate);
 				}
 				
 				String docFilename = doc.getFilename().toLowerCase();
@@ -675,7 +675,7 @@ public class DatalayerServiceImpl implements DatalayerService {
 		
 		return response;
 	}
-	
+
 	public Response getToken(String url, String username, String password){
 		return Response.ok(this.requestToken(url, username, password)).status(Status.OK).build();
 	}
@@ -946,5 +946,20 @@ public class DatalayerServiceImpl implements DatalayerService {
 		return Response.status(Status.BAD_REQUEST).entity(
 				Status.FORBIDDEN.getReasonPhrase()).build();
 	}
-	
+
+	/**
+	 * Parses refresh rate presented as a string into an integer. If the string cannot be parsed, logs a warning and
+	 * returns a default value.
+	 *
+	 * @param refreshRate The refresh rate as a string
+	 * @return The refresh rate as an integer
+	 */
+	private int parseRefreshRate(String refreshRate) {
+		try {
+			return Integer.parseInt(refreshRate);
+		} catch (NumberFormatException nfe) {
+			logger.warn(String.format("Unable to parse %s, defaulting to 300 seconds", refreshRate));
+			return 300;
+		}
+	}
 }


### PR DESCRIPTION
# Summary

Provides a default value of 5:00 for KML and KMZ imports that do not specify a refresh rate.

# What's New

KML and KMZ imports where the end user does not select a refresh rate in the NICS Web application will have a 5:00 refresh rate as a default value.

# What's Changed

This addresses a defect where refresh rate is presented to the user as optional but, in fact, the system requires a refresh rate value for all KML and KMZ imports. KML and KMZ imports that do not specify a refresh rate should succeed now rather than fail.
