### PR TITLE
OES33: Roll back changes to OpenAM when registration fails

### DIFF
--- a/api-rest-common/src/main/java/edu/mit/ll/em/api/rs/RegisterUser.java
+++ b/api-rest-common/src/main/java/edu/mit/ll/em/api/rs/RegisterUser.java
@@ -29,6 +29,8 @@
  */
 package edu.mit.ll.em.api.rs;
 
+import org.apache.commons.lang.builder.ToStringBuilder;
+
 public class RegisterUser extends APIBean {
 
 	private String password;
@@ -182,5 +184,7 @@ public class RegisterUser extends APIBean {
 		this.teams = teams;
 	}
 	
-	
+	public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
 }

--- a/api-rest-service/pom.xml
+++ b/api-rest-service/pom.xml
@@ -191,5 +191,18 @@
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
 		</dependency>
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.3.7</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 </project>

--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/openam/OpenAmGateway.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/openam/OpenAmGateway.java
@@ -88,10 +88,10 @@ public class OpenAmGateway {
         String propPath = APIConfig.getInstance().getConfiguration()
                 .getString("ssoToolsPropertyPath", null);
 
-        log.i("OpenAmGateway:createIdentityUser", "Initializing SSOUtils with property path: " + propPath);
+        log.i("OpenAmGateway:setSSOUtilsProperties", "Initializing SSOUtils with property path: " + propPath);
         if(propPath == null) {
             // send email to admins about sso not configured
-            log.w("UserServiceImpl", "Got null SSO configuration, won't be able to make SSO calls!");
+            log.w("OpenAmGateway", "Got null SSO configuration, won't be able to make SSO calls!");
             response = buildJSONResponse("fail", "'ssoToolsPropertyPath' not set, cannot make SSO related calls.");
         } else {
             System.setProperty("ssoToolsPropertyPath", propPath);
@@ -103,16 +103,14 @@ public class OpenAmGateway {
     /**
      * Deletes an identity user from OpenAM
      *
-     * <p>NOT YET IMPLEMENTED</p>
-     *
-     * @param email
-     * @return
+     * @param uid
+     * @return A JSON response in the form: {"status":"success/fail", "message":"MESSAGE"}
      */
     public JSONObject deleteIdentityUser(String uid) {
 
         SSOUtil ssoUtil = null;
         boolean login = false;
-        String creationResponse = "";
+        String deletionResponse = "";
         JSONObject response = this.setSSOUtilsProperties();
 
         if(response == null) {
@@ -120,9 +118,9 @@ public class OpenAmGateway {
             login = ssoUtil.loginAsAdmin();
 
             if(login) {
-                creationResponse = ssoUtil.deleteUser(uid); // TODO: need to implement delete identity call
+                deletionResponse = ssoUtil.deleteUser(uid);
                 try {
-                    response = new JSONObject(creationResponse);
+                    response = new JSONObject(deletionResponse);
                 } catch(JSONException e) {
                     // can't read response, assume failure
                     response = buildJSONResponse("fail", "JSON exception reading delete identity response: " +

--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/openam/OpenAmGateway.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/openam/OpenAmGateway.java
@@ -56,39 +56,19 @@ public class OpenAmGateway {
     public JSONObject createIdentityUser(User user, RegisterUser registerUser) {
         boolean login = false;
         String creationResponse = "";
-        JSONObject response = this.setSSOUtilsProperties();
-
-        if (response == null) {
-            login = ssoUtil.loginAsAdmin();
-            if (login) {
-                creationResponse = ssoUtil.createUser(user.getUsername(), registerUser.getPassword(),
-                        user.getFirstname(), user.getLastname(), false);
-                try {
-                    response = new JSONObject(creationResponse);
-                } catch (JSONException e) {
-                    // can't read response, assume failure
-                    response = buildJSONResponse("fail", "JSON exception reading createUser response: " + e.getMessage());
-                }
-            } else {
-                response = buildJSONResponse("fail", "Failed to log in as Administrator with SSOUtil. Cannot create Identity.");
-            }
-        }
-        return response;
-    }
-
-    private JSONObject setSSOUtilsProperties() {
         JSONObject response = null;
-        String propPath = APIConfig.getInstance().getConfiguration()
-                .getString("ssoToolsPropertyPath", null);
 
-        log.i("OpenAmGateway:setSSOUtilsProperties", "Initializing SSOUtils with property path: " + propPath);
-        if(propPath == null) {
-            // send email to admins about sso not configured
-            log.w("OpenAmGateway", "Got null SSO configuration, won't be able to make SSO calls!");
-            response = buildJSONResponse("fail", "'ssoToolsPropertyPath' not set, cannot make SSO related calls.");
+        if (ssoUtil.loginAsAdmin()) {
+            creationResponse = ssoUtil.createUser(user.getUsername(), registerUser.getPassword(),
+                    user.getFirstname(), user.getLastname(), false);
+            try {
+                response = new JSONObject(creationResponse);
+            } catch (JSONException e) {
+                // can't read response, assume failure
+                response = buildJSONResponse("fail", "JSON exception reading createUser response: " + e.getMessage());
+            }
         } else {
-            System.setProperty("ssoToolsPropertyPath", propPath);
-            System.setProperty("openamPropertiesPath", propPath);
+            response = buildJSONResponse("fail", "Failed to log in as Administrator with SSOUtil. Cannot create Identity.");
         }
         return response;
     }
@@ -102,24 +82,20 @@ public class OpenAmGateway {
     public JSONObject deleteIdentityUser(String uid) {
         boolean login = false;
         String deletionResponse = "";
-        JSONObject response = this.setSSOUtilsProperties();
+        JSONObject response = null;
 
-        if(response == null) {
-            login = ssoUtil.loginAsAdmin();
-
-            if(login) {
-                deletionResponse = ssoUtil.deleteUser(uid);
-                try {
-                    response = new JSONObject(deletionResponse);
-                } catch(JSONException e) {
-                    // can't read response, assume failure
-                    response = buildJSONResponse("fail", "JSON exception reading delete identity response: " +
-                            e.getMessage());
-                }
-            } else {
-                response = buildJSONResponse("fail",
-                        "Failed to log in as Administrator with SSOUtil. Cannot delete Identity with uid : " + uid);
+        if(ssoUtil.loginAsAdmin()) {
+            deletionResponse = ssoUtil.deleteUser(uid);
+            try {
+                response = new JSONObject(deletionResponse);
+            } catch(JSONException e) {
+                // can't read response, assume failure
+                response = buildJSONResponse("fail", "JSON exception reading delete identity response: " +
+                        e.getMessage());
             }
+        } else {
+            response = buildJSONResponse("fail",
+                    "Failed to log in as Administrator with SSOUtil. Cannot delete Identity with uid : " + uid);
         }
         return response;
     }

--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/openam/OpenAmGateway.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/openam/OpenAmGateway.java
@@ -40,15 +40,10 @@ import org.json.JSONObject;
 public class OpenAmGateway {
 
     private static final APILogger log = APILogger.getInstance();
-    private static OpenAmGateway openAmGateway;
+    private SSOUtil ssoUtil;
 
-    public static OpenAmGateway getInstance() {
-        if(openAmGateway == null)
-            openAmGateway = new OpenAmGateway();
-        return openAmGateway;
-    }
-
-    private OpenAmGateway() {
+    public OpenAmGateway(SSOUtil ssoUtil) {
+        this.ssoUtil = ssoUtil;
     }
 
     /**
@@ -59,13 +54,11 @@ public class OpenAmGateway {
      * @return A JSON response in the form: {"status":"success/fail", "message":"MESSAGE"}
      */
     public JSONObject createIdentityUser(User user, RegisterUser registerUser) {
-        SSOUtil ssoUtil = null;
         boolean login = false;
         String creationResponse = "";
         JSONObject response = this.setSSOUtilsProperties();
 
         if (response == null) {
-            ssoUtil = new SSOUtil();
             login = ssoUtil.loginAsAdmin();
             if (login) {
                 creationResponse = ssoUtil.createUser(user.getUsername(), registerUser.getPassword(),
@@ -107,14 +100,11 @@ public class OpenAmGateway {
      * @return A JSON response in the form: {"status":"success/fail", "message":"MESSAGE"}
      */
     public JSONObject deleteIdentityUser(String uid) {
-
-        SSOUtil ssoUtil = null;
         boolean login = false;
         String deletionResponse = "";
         JSONObject response = this.setSSOUtilsProperties();
 
         if(response == null) {
-            ssoUtil = new SSOUtil();
             login = ssoUtil.loginAsAdmin();
 
             if(login) {

--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/openam/OpenAmGateway.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/openam/OpenAmGateway.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2008-2016, Massachusetts Institute of Technology (MIT)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package edu.mit.ll.em.api.openam;
+
+import edu.mit.ll.em.api.rs.RegisterUser;
+import edu.mit.ll.em.api.util.APIConfig;
+import edu.mit.ll.em.api.util.APILogger;
+import edu.mit.ll.nics.common.entity.User;
+import edu.mit.ll.nics.sso.util.SSOUtil;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class OpenAmGateway {
+
+    private static final APILogger log = APILogger.getInstance();
+    private static OpenAmGateway openAmGateway;
+
+    public static OpenAmGateway getInstance() {
+        if(openAmGateway == null)
+            openAmGateway = new OpenAmGateway();
+        return openAmGateway;
+    }
+
+    private OpenAmGateway() {
+    }
+
+    /**
+     * Uses SSOUtil to create an Identity user in OpenAM
+     *
+     * @param user User to register
+     * @param registerUser The RegisterUser object resulting from a registration request
+     * @return A JSON response in the form: {"status":"success/fail", "message":"MESSAGE"}
+     */
+    public JSONObject createIdentityUser(User user, RegisterUser registerUser) {
+        SSOUtil ssoUtil = null;
+        boolean login = false;
+        String creationResponse = "";
+        JSONObject response = this.setSSOUtilsProperties();
+
+        if (response == null) {
+            ssoUtil = new SSOUtil();
+            login = ssoUtil.loginAsAdmin();
+            if (login) {
+                creationResponse = ssoUtil.createUser(user.getUsername(), registerUser.getPassword(),
+                        user.getFirstname(), user.getLastname(), false);
+                try {
+                    response = new JSONObject(creationResponse);
+                } catch (JSONException e) {
+                    // can't read response, assume failure
+                    response = buildJSONResponse("fail", "JSON exception reading createUser response: " + e.getMessage());
+                }
+            } else {
+                response = buildJSONResponse("fail", "Failed to log in as Administrator with SSOUtil. Cannot create Identity.");
+            }
+        }
+        return response;
+    }
+
+    private JSONObject setSSOUtilsProperties() {
+        JSONObject response = null;
+        String propPath = APIConfig.getInstance().getConfiguration()
+                .getString("ssoToolsPropertyPath", null);
+
+        log.i("OpenAmGateway:createIdentityUser", "Initializing SSOUtils with property path: " + propPath);
+        if(propPath == null) {
+            // send email to admins about sso not configured
+            log.w("UserServiceImpl", "Got null SSO configuration, won't be able to make SSO calls!");
+            response = buildJSONResponse("fail", "'ssoToolsPropertyPath' not set, cannot make SSO related calls.");
+        } else {
+            System.setProperty("ssoToolsPropertyPath", propPath);
+            System.setProperty("openamPropertiesPath", propPath);
+        }
+        return response;
+    }
+
+    /**
+     * Deletes an identity user from OpenAM
+     *
+     * <p>NOT YET IMPLEMENTED</p>
+     *
+     * @param email
+     * @return
+     */
+    public JSONObject deleteIdentityUser(String uid) {
+
+        SSOUtil ssoUtil = null;
+        boolean login = false;
+        String creationResponse = "";
+        JSONObject response = this.setSSOUtilsProperties();
+
+        if(response == null) {
+            ssoUtil = new SSOUtil();
+            login = ssoUtil.loginAsAdmin();
+
+            if(login) {
+                creationResponse = ssoUtil.deleteUser(uid); // TODO: need to implement delete identity call
+                try {
+                    response = new JSONObject(creationResponse);
+                } catch(JSONException e) {
+                    // can't read response, assume failure
+                    response = buildJSONResponse("fail", "JSON exception reading delete identity response: " +
+                            e.getMessage());
+                }
+            } else {
+                response = buildJSONResponse("fail",
+                        "Failed to log in as Administrator with SSOUtil. Cannot delete Identity with uid : " + uid);
+            }
+        }
+        return response;
+    }
+
+    /**
+     * Builds a JSON response object
+     *
+     * @param status Content of the status field
+     * @param message A message explaining the status
+     * @return A JSONObject with a 'status' and 'message' field populated if successful,
+     * 			otherwise an empty JSONObject
+     */
+    private JSONObject buildJSONResponse(String status, String message) {
+        JSONObject response = new JSONObject();
+
+        try {
+            response.put("status", status);
+            response.put("message", message);
+        } catch(JSONException e) {
+            APILogger.getInstance().e("OpenAmGateway:buildJSONResponse", "JSONException building response: " +
+                    e.getMessage());
+        }
+        return response;
+    }
+}

--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/openam/OpenAmGateway.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/openam/OpenAmGateway.java
@@ -37,6 +37,11 @@ import edu.mit.ll.nics.sso.util.SSOUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+/**
+ * To instantiate OpenAmGateway, we need an instance of SSOUtil. Before instantiating SSOUtil please make sure
+ * to add ssoToolsPropertyPath as System property. Please see UserServicesImpl.getOpenAmGatewayInstance()
+ * for example.
+ */
 public class OpenAmGateway {
 
     private static final APILogger log = APILogger.getInstance();

--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/UserServiceImpl.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/UserServiceImpl.java
@@ -117,7 +117,6 @@ public class UserServiceImpl implements UserService {
 	private final UserOrgDAOImpl userOrgDao = new UserOrgDAOImpl();
 	private final UserSessionDAOImpl userSessDao = new UserSessionDAOImpl();
 	private final OrgDAOImpl orgDao = new OrgDAOImpl();
-    private final OpenAmGateway openAmGateway = OpenAmGateway.getInstance();
 	
 	private RabbitPubSubProducer rabbitProducer;
 
@@ -348,6 +347,7 @@ public class UserServiceImpl implements UserService {
      * @throws Exception
      */
     private Response registerUser(RegisterUser registerUser, User user, Org primaryOrg, List<UserOrg> userOrgs, List<UserOrgWorkspace> userOrgWorkspaces, List<Contact> contactSet) throws Exception {
+        OpenAmGateway openAmGateway = new OpenAmGateway(new SSOUtil());
         Response response = null;
         JSONObject createdIdentity = openAmGateway.createIdentityUser(user, registerUser);
         if(!createdIdentity.optString("status", "").equals(SUCCESS)) {
@@ -389,7 +389,8 @@ public class UserServiceImpl implements UserService {
     }
 
     private boolean deleteIdentityUser(RegisterUser registerUser, User user, Org primaryOrg) throws Exception {
-        JSONObject response = this.openAmGateway.deleteIdentityUser(registerUser.getEmail());
+        OpenAmGateway openAmGateway = new OpenAmGateway(new SSOUtil());
+        JSONObject response = openAmGateway.deleteIdentityUser(registerUser.getEmail());
         boolean deleteSuccessful = false;
         if(SUCCESS.equals(response.getString("status"))) {
             log.i("UserServiceImpl", "Successfully deleted identity user with uid " + registerUser.getEmail() + "from OpenAm");

--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/UserServiceImpl.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/UserServiceImpl.java
@@ -376,6 +376,8 @@ public class UserServiceImpl implements UserService {
             boolean registerSuccess = userDao.registerUser(user, contactSet, userOrgs, userOrgWorkspaces);
             if (registerSuccess) {
                 notifySuccessfulRegistration(registerUser, user, primaryOrg);
+            } else {
+                return Response.ok("Failed to register user with system. Please try again later.").status(Status.INTERNAL_SERVER_ERROR).build();
             }
         } catch(Exception e) {
             System.out.println("Exception persisting user: " + e.getMessage());

--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/UserServiceImpl.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/UserServiceImpl.java
@@ -49,11 +49,11 @@ import javax.ws.rs.core.Response.Status;
 
 import edu.mit.ll.nics.common.rabbitmq.RabbitFactory;
 import edu.mit.ll.nics.common.rabbitmq.RabbitPubSubProducer;
+import edu.mit.ll.em.api.openam.OpenAmGateway;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.dao.DataAccessException;
 
@@ -117,6 +117,7 @@ public class UserServiceImpl implements UserService {
 	private final UserOrgDAOImpl userOrgDao = new UserOrgDAOImpl();
 	private final UserSessionDAOImpl userSessDao = new UserSessionDAOImpl();
 	private final OrgDAOImpl orgDao = new OrgDAOImpl();
+    private final OpenAmGateway openAmGateway = OpenAmGateway.getInstance();
 	
 	private RabbitPubSubProducer rabbitProducer;
 
@@ -280,343 +281,212 @@ public class UserServiceImpl implements UserService {
 		}
 		return Response.ok(userResponse).status(Status.OK).build();
 	}
-	
+
 	/**
 	 * Creation of a single User item.
 	 * 
-	 * @param User to be created.
+	 * @param registerUser to be created.
 	 * @return Response
 	 * @see UserResponse
 	 */	
 	public Response postUser(int workspaceId, RegisterUser registerUser) {
-		String successMessage = "Successfully registered user";
-		
+        Org primaryOrg;
+        edu.mit.ll.nics.common.entity.User user;
+        List<UserOrg> userOrgs = new ArrayList<UserOrg>();
+        List<UserOrgWorkspace> userOrgWorkspaces = new ArrayList<UserOrgWorkspace>();
+        OrgDAOImpl orgDao = new OrgDAOImpl();
+        Response response;
+
 		try{
-			edu.mit.ll.nics.common.entity.User user = createUser(registerUser);
+			user = createUser(registerUser);
 			String validate = validateRegisterUser(registerUser);
-			
-			if(!validate.equals(SUCCESS)) {
+			if(!validate.equals(SUCCESS))
 				return Response.ok(validate).status(Status.PRECONDITION_FAILED).build();
-			}
-			
-			// Create the Identity for the user, only proceed if it succeeds
-			JSONObject createdIdentity = createIdentityUser(user, registerUser);
-						
-			if(!createdIdentity.optString("status", "").equals(SUCCESS)) {
-				return Response.ok("Failed to create identity. " + createdIdentity.optString("message", "unknown"))
-						.status(Status.PRECONDITION_FAILED).build();
-			}
 
-			Collection<Org> orgs = new ArrayList<Org>();
+            primaryOrg = orgDao.getOrganization(registerUser.getOrganization());
+            if(primaryOrg == null) // need to fail, can't get org
+                return Response.ok(FAILURE_ORG_INVALID + ": " + registerUser.getOrganization()).status(Status.PRECONDITION_FAILED).build();
+            UserOrg primaryUserOrg = createUserOrg(primaryOrg.getOrgId(), user.getUserId(), registerUser);
+            if(primaryUserOrg == null) {
+                log.w("UserService", "!!! FAILED to create userOrg for user: " + registerUser.getEmail());
+                return Response.ok("Failed to create UserOrg with orgId '" + primaryOrg.getOrgId() +
+                        "' and userId '" + user.getUserId() + "' for user: " + registerUser.getEmail()).
+                        status(Status.PRECONDITION_FAILED).build();
+            }
+            try{
+                userOrgs.add(primaryUserOrg);
+                userOrgs.addAll(getUserOrgTeams(registerUser, user));
+                userOrgWorkspaces = getUserOrgWorkspaceTeams(userOrgs);
+            }catch(Exception e){
+                e.printStackTrace();
+                log.e("UserServiceImpl", "Exception while creating Team UserOrg and Primary Org & Team UserOrgWorkspace on input: " +
+                        registerUser);
+                return Response.ok("Exception while creating Team UserOrg and UserOrgWorkspace on input: " +
+                        Arrays.toString(registerUser.getTeams())).status(Status.PRECONDITION_FAILED).build();
+            }
+            List<Contact> contactSet = createContactsList(registerUser.getEmail(), registerUser.getOtherEmail(), registerUser.getOfficePhone(), registerUser.getCellPhone(), registerUser.getOtherPhone(),
+                    registerUser.getRadioNumber(), user);
 
-			OrgDAOImpl orgDao = new OrgDAOImpl();
-			Org org = orgDao.getOrganization(registerUser.getOrganization());
-			if(org == null) {
-				// need to fail, can't get org
-				return Response.ok(FAILURE_ORG_INVALID + ": " + registerUser.getOrganization())
-						.status(Status.PRECONDITION_FAILED).build();
-			}
-			UserOrg userOrg = createUserOrg(org.getOrgId(), user.getUserId(), registerUser);
-
-			if(userOrg == null) {
-				log.w("UserService", "!!! FAILED to create userOrg for user: " + registerUser.getEmail());
-				return Response.ok("Failed to create UserOrg with orgId '" + org.getOrgId() + 
-						"' and userId '" + user.getUserId() + "' for user: " + registerUser.getEmail()).
-						status(Status.PRECONDITION_FAILED).build();
-			}
-
-			orgs.add(org);
-
-			String[] teams = registerUser.getTeams();
-
-			Collection<SADisplayMessageEntity> userTeams = new ArrayList<SADisplayMessageEntity>();
-			List<UserOrg> userOrgsTeams = new ArrayList<UserOrg>();
-			List<UserOrgWorkspace> userOrgWorkspacesTeams = new ArrayList<UserOrgWorkspace>();
-			if(teams != null && teams.length > 0){
-				try{
-					for(int i = 0; i < teams.length; i++) {						
-						Org teamOrg = orgDao.getOrganization(teams[i]);
-						if(teamOrg == null) {
-							log.i("UserServiceImpl", "Org does not exist: " + teams[i]);
-							continue;
-						}
-						
-						UserOrg team = createUserOrg(teamOrg.getOrgId(), user.getUserId(), registerUser);
-						if(team != null) {
-							userTeams.add(team);
-							userOrgsTeams.add(team);
-
-							userTeams.addAll(createUserOrgWorkspace(team.getUserorgid(), false));
-							userOrgWorkspacesTeams.addAll(createUserOrgWorkspaceEntities(team, false));
-						}
-						orgs.add(teamOrg);
-					}
-				}catch(Exception e){
-					e.printStackTrace();
-
-					log.e("UserServiceImpl", "Exception while creating Team UserOrg and UserOrgWorkspace on input: " + 
-							Arrays.toString(teams));
-
-					return Response.ok("Exception while creating Team UserOrg and UserOrgWorkspace on input: " + 
-							Arrays.toString(teams)).status(Status.PRECONDITION_FAILED).build();
-				}
-			}
-
-			// DBI createUser creates the contacts if they're set, TODO: it gets new ids, but these should already
-			// have them
-			List<Contact> contactSet = createContactsList(registerUser.getEmail(), 
-					registerUser.getOtherEmail(),
-					registerUser.getOfficePhone(),
-					registerUser.getCellPhone(), 
-					registerUser.getOtherPhone(),
-					registerUser.getRadioNumber(), user);
-
-
-			String createUserStatus = "";
-			try {
-
-				List<UserOrg> userOrgs = new ArrayList<UserOrg>();
-				List<UserOrgWorkspace> userOrgWorkspaces = new ArrayList<UserOrgWorkspace>();
-
-				userOrgs.add(userOrg);
-				if(userOrgsTeams != null && !userOrgsTeams.isEmpty()) {
-					userOrgs.addAll(userOrgsTeams);
-				}
-
-				userOrgWorkspaces.addAll(createUserOrgWorkspaceEntities(userOrg, false));
-				if(userOrgWorkspacesTeams != null && !userOrgWorkspacesTeams.isEmpty()) {
-					userOrgWorkspaces.addAll(userOrgWorkspacesTeams);
-				}						
-
-				boolean registerSuccess = userDao.registerUser(user, contactSet, userOrgs, userOrgWorkspaces);
-
-				if(!registerSuccess) {
-
-					// TODO: in addition to failing, need to delete identity user. The backend in openam-tools
-					// and sso-tools does noet yet expose a method for deleting an identity user
-					//JSONObject deleteResponse = deleteIdentityUser(registerUser.getEmail());
-					
-					// TODO: build helper method for sending email
-					// TODO: email admin if delete failed? Until the createidentity code takes into account
-					// an existing user, will have to require this call works. Or we can merge the identities
-					// including using the latest password, in case it differs from original
-					try {
-						String fromEmail = APIConfig.getInstance().getConfiguration().getString(APIConfig.NEW_USER_ALERT_EMAIL);
-						String date = new SimpleDateFormat("EEE MMM d HH:mm:ss z yyyy").format(new Date());
-						String alertTopic = APIConfig.getInstance().getConfiguration().getString(APIConfig.EMAIL_ALERT_TOPIC,
-								"iweb.nics.email.alert");
-						String sysAdmins = APIConfig.getInstance().getConfiguration()
-								.getString(APIConfig.SYSTEM_ADMIN_ALERT_EMAILS, "");
-						String hostname = InetAddress.getLocalHost().getHostName();
-						//List<String>  disList = orgDao.getOrgAdmins(org.getOrgId());
-						//String toEmails = disList.toString().substring(1, disList.toString().length() - 1) + ", " + sysAdmins;
-						String toEmails = sysAdmins;
-
-						//if(disList.size() > 0 && !fromEmail.isEmpty()){
-						if(!sysAdmins.isEmpty()) {
-							JsonEmail email = new JsonEmail(fromEmail, toEmails,
-									"Alert from RegisterAccount@" + hostname);
-							email.setBody(date + "\n\n" + "A new user has attempted to register" + 
-									". However, their system user failed to successfully persist, so before" +
-									" they can try to register again with the same email address, their" +
-									" Identity user will need deleted in OpenAM.\n\n" +
-									"Name: " + user.getFirstname() + " " + user.getLastname() + "\n" +
-									"Organization: " + org.getName() + "\n" +
-									"Email: " + user.getUsername() + "\n" + 
-									"Other Information: " + registerUser.getOtherInfo());
-
-							notifyNewUserEmail(email.toJsonObject().toString(),alertTopic);
-						}
-
-					} catch (Exception e) {
-						APILogger.getInstance().e(CNAME,"Failed to send registration failed email to Org Admins and System Admins");
-					}
-
-					return Response.ok("Failed to successfully register user with system, but registration with"
-							+ " the identity provider succeeded. Before attempting to register with this"
-							+ " email address again, a system administrator will need to delete your identity user."
-							+ " An email has been sent on your behalf.")
-							.status(Status.EXPECTATION_FAILED).build();
-				}
-
-				
-				try {
-					String fromEmail = APIConfig.getInstance().getConfiguration().getString(APIConfig.NEW_USER_ALERT_EMAIL);
-					String date = new SimpleDateFormat("EEE MMM d HH:mm:ss z yyyy").format(new Date());					
-					String alertTopic = APIConfig.getInstance().getConfiguration().getString(APIConfig.EMAIL_ALERT_TOPIC,
-							"iweb.nics.email.alert");
-					String newRegisteredUsers = APIConfig.getInstance().getConfiguration().getString(APIConfig.NEW_REGISTERED_USER_EMAIL);
-					String hostname = InetAddress.getLocalHost().getHostName();
-					List<String>  disList = orgDao.getOrgAdmins(org.getOrgId());
-					String toEmails = disList.toString().substring(1, disList.toString().length() - 1) + ", " + newRegisteredUsers;
-
-					if(disList.size() > 0 && !fromEmail.isEmpty()){
-						JsonEmail email = new JsonEmail(fromEmail,toEmails,
-								"Alert from RegisterAccount@" + hostname);
-						email.setBody(date + "\n\n" + "A new user has registered: " + user.getUsername() + "\n" + 
-								"Name: " + user.getFirstname() + " " + user.getLastname() + "\n" + 
-								"Organization: " + org.getName() + "\n" +
-								"Email: " + user.getUsername() + "\n" + 
-								"Other Information: " + registerUser.getOtherInfo());
-
-						notifyNewUserEmail(email.toJsonObject().toString(),alertTopic);
-					}
-
-				} catch (Exception e) {
-					e.printStackTrace();
-					APILogger.getInstance().e(CNAME,"Failed to send new User email alerts");
-				}
-
-
-			} catch(DataAccessException e) { //catch(ICSDatastoreException e) {
-				System.out.println("Exception persisting user: " + e.getMessage());
-				log.e("UserServiceImpl", "Exception creating user: " + e.getMessage());
-				return Response.ok("Failed to register user: " + e.getMessage()).status(Status.INTERNAL_SERVER_ERROR).build();
-			} catch(Exception e) {
-				System.out.println("Exception persisting user: " + e.getMessage());
-				log.e("UserServiceImpl", "Exception creating user: " + e.getMessage());
-				return Response.ok("Failed to register user: " + e.getMessage()).status(Status.INTERNAL_SERVER_ERROR).build();
-			}
-			
+            response = this.registerUser(registerUser, user, primaryOrg, userOrgs, userOrgWorkspaces, contactSet);
 		}catch(Exception e){
-			e.printStackTrace();
+			log.e("UserServiceImpl", "Error registering user : " + registerUser + ", Exception: " + e.getMessage());
 			return Response.ok(FAILURE).status(Status.INTERNAL_SERVER_ERROR).build();
 		}
 		
-		return Response.ok(successMessage + registerUser.getEmail()).status(Status.OK).build();
-	}
-	
-	
-	/**
-	 * Uses SSOUtil to create an Identity user in OpenAM
-	 * 
-	 * @param user User to register
-	 * @param registerUser The RegisterUser object resulting from a registration request
-	 * @return A JSON response in the form: {"status":"success/fail", "message":"MESSAGE"}
-	 */
-	private JSONObject createIdentityUser(User user, RegisterUser registerUser) {
-		
-		String propPath = APIConfig.getInstance().getConfiguration()
-				.getString("ssoToolsPropertyPath", null);
-		
-		log.i("UserServiceImpl:createIdentityUser", "Initializing SSOUtils with property path: " + propPath);
-				
-		SSOUtil ssoUtil = null;
-		boolean login = false;
-		String creationResponse = "";
-		JSONObject response = null;
-		
-		if(propPath == null) {
-			// send email to admins about sso not configured
-			log.w("UserServiceImpl", "Got null SSO configuration, won't be able to make SSO calls!");
-			response = buildJSONResponse("fail", "'ssoToolsPropertyPath' not set, cannot make SSO related calls.");
-		} else {
-			System.setProperty("ssoToolsPropertyPath", propPath);
-			System.setProperty("openamPropertiesPath", propPath);
-			
-			ssoUtil = new SSOUtil();
-			login = ssoUtil.loginAsAdmin();
-			
-			if(login) {
-				creationResponse = ssoUtil.createUser(user.getUsername(), registerUser.getPassword(),
-						user.getFirstname(), user.getLastname(), false);
-							
-				try {
-					response = new JSONObject(creationResponse);
-					
-				} catch(JSONException e) {
-					// can't read response, assume failure
-					response = buildJSONResponse("fail", "JSON exception reading createUser response: " + 
-							e.getMessage());
-				}
-				
-			} else {
-				response = buildJSONResponse("fail", 
-						"Failed to log in as Administrator with SSOUtil. Cannot create Identity.");
-			}
-		}		
-		 
 		return response;
 	}
-	
-	
-	/**
-	 * Deletes an identity user from OpenAM
-	 * 
-	 * <p>NOT YET IMPLEMENTED</p>
-	 * 
-	 * @param email
-	 * @return
-	 */
-	private JSONObject deleteIdentityUser(String email) {
-				
-		String propPath = APIConfig.getInstance().getConfiguration()
-				.getString("ssoToolsPropertyPath", null);
-		
-		log.i("UserServiceImpl:deleteIdentityUser", "Initializing SSOUtils with property path: " + propPath);
-				
-		SSOUtil ssoUtil = null;
-		boolean login = false;
-		String creationResponse = "";
-		JSONObject response = null;
-		
-		if(propPath == null) {
-			// send email to admins about sso not configured
-			log.w("UserServiceImpl", "Got null SSO configuration, won't be able to make SSO calls!");
-			response = buildJSONResponse("fail", "'ssoToolsPropertyPath' not set, cannot make SSO related calls.");
-		} else {
-			System.setProperty("ssoToolsPropertyPath", propPath);
-			System.setProperty("openamPropertiesPath", propPath);
-			
-			ssoUtil = new SSOUtil();
-			login = ssoUtil.loginAsAdmin();
-			
-			if(login) {
-				creationResponse = null; // TODO: need to implement delete identity call
-							
-				try {
-					response = new JSONObject(creationResponse);
-					
-				} catch(JSONException e) {
-					// can't read response, assume failure
-					response = buildJSONResponse("fail", "JSON exception reading delete identity response: " + 
-							e.getMessage());
-				}
-				
-			} else {
-				response = buildJSONResponse("fail", 
-						"Failed to log in as Administrator with SSOUtil. Cannot delete Identity.");
-			}
-		}		
-		
-		//return response;
-		// TODO: Not implemented
-		return buildJSONResponse("fail", "Deleting identity not yet implemented");
-	}
-	
-	
-	/**
-	 * Builds a JSON response object
-	 * 
-	 * @param status Content of the status field
-	 * @param message A message explaining the status
-	 * @return A JSONObject with a 'status' and 'message' field populated if successful,
-	 * 			otherwise an empty JSONObject
-	 */
-	public JSONObject buildJSONResponse(String status, String message) {
-		JSONObject response = new JSONObject();
-		
-		try {
-			response.put("status", status);
-			response.put("message", message);
-		} catch(JSONException e) {
-			APILogger.getInstance().e("UserServiceImpl:buildJSONResponse", "JSONException building response: " + 
-					e.getMessage());
-		}
-		
-		return response;
-	}
-	
+
+    /**
+     *
+     * @param registerUser
+     * @param user
+     * @param primaryOrg
+     * @param userOrgs
+     * @param userOrgWorkspaces
+     * @param contactSet
+     * @return Response with information of successful or failed registration
+     * @throws Exception
+     */
+    private Response registerUser(RegisterUser registerUser, User user, Org primaryOrg, List<UserOrg> userOrgs, List<UserOrgWorkspace> userOrgWorkspaces, List<Contact> contactSet) throws Exception {
+        Response response = null;
+        JSONObject createdIdentity = openAmGateway.createIdentityUser(user, registerUser);
+        if(!createdIdentity.optString("status", "").equals(SUCCESS)) {
+            response = Response.ok("Failed to create identity. " + createdIdentity.optString("message", "unknown"))
+                    .status(Status.PRECONDITION_FAILED).build();
+        } else { //delete user from OpenAm
+            response = this.createUserInDB(registerUser, user, primaryOrg, userOrgs, userOrgWorkspaces, contactSet);
+            if (response.getStatus() != Status.OK.getStatusCode()) {
+                boolean deleteSuccessful = this.deleteIdentityUser(registerUser, user, primaryOrg);
+                if (!deleteSuccessful)
+                    response = Response.ok("Failed to successfully register user with system, but registration with"
+                            + " the identity provider succeeded. Before attempting to register with this"
+                            + " email address again, a system administrator will need to delete your identity user."
+                            + " An email has been sent on your behalf.")
+                            .status(Status.EXPECTATION_FAILED).build();
+            }
+        }
+        return response;
+    }
+
+    private Response createUserInDB(RegisterUser registerUser, User user, Org primaryOrg, List<UserOrg> userOrgs, List<UserOrgWorkspace> userOrgWorkspaces, List<Contact> contactSet) throws Exception {
+        String successMessage = "Successfully registered user";
+
+        String createUserStatus = "";
+        try {
+            boolean registerSuccess = userDao.registerUser(user, contactSet, userOrgs, userOrgWorkspaces);
+            if (registerSuccess) {
+                notifySuccessfulRegistration(registerUser, user, primaryOrg);
+            }
+        } catch(Exception e) {
+            System.out.println("Exception persisting user: " + e.getMessage());
+            log.e("UserServiceImpl", "Exception creating user: " + e.getMessage());
+            return Response.ok("Failed to register user: " + e.getMessage()).status(Status.INTERNAL_SERVER_ERROR).build();
+        }
+
+        return Response.ok(successMessage + registerUser.getEmail()).status(Status.OK).build();
+    }
+
+    private boolean deleteIdentityUser(RegisterUser registerUser, User user, Org primaryOrg) throws Exception {
+        JSONObject response = this.openAmGateway.deleteIdentityUser(registerUser.getEmail());
+        boolean deleteSuccessful = false;
+        if(SUCCESS.equals(response.getString("status"))) {
+            log.i("UserServiceImpl", "Successfully deleted identity user with uid " + registerUser.getEmail() + "from OpenAm");
+            deleteSuccessful = true;
+        } else {
+            this.notifyFailedRegistration(registerUser, user, primaryOrg);
+        }
+        return deleteSuccessful;
+    }
+
+    private List<UserOrg> getUserOrgTeams(RegisterUser registerUser, User user) throws Exception {
+        List<UserOrg> userOrgTeams = new ArrayList<UserOrg>();
+        String[] teams = registerUser.getTeams();
+        if(teams != null && teams.length > 0) {
+            for (int i = 0; i < teams.length; i++) {
+                Org teamOrg = orgDao.getOrganization(teams[i]);
+                if (teamOrg == null) {
+                    log.i("UserServiceImpl", "Org does not exist: " + teams[i]);
+                    continue;
+                } else {
+                    UserOrg userOrgTeam = createUserOrg(teamOrg.getOrgId(), user.getUserId(), registerUser);
+                    if (userOrgTeam != null) {
+                        userOrgTeams.add(userOrgTeam);
+                    }
+                }
+            }
+        }
+        return userOrgTeams;
+    }
+
+    private List<UserOrgWorkspace> getUserOrgWorkspaceTeams(List<UserOrg> userOrgTeams) {
+        List<UserOrgWorkspace> userOrgWorkspacesTeams = new ArrayList<UserOrgWorkspace>();
+        for(UserOrg userOrgTeam : userOrgTeams) {
+            userOrgWorkspacesTeams.addAll(createUserOrgWorkspaceEntities(userOrgTeam, false));
+        }
+        return userOrgWorkspacesTeams;
+    }
+
+    private void notifySuccessfulRegistration(RegisterUser registerUser, User user, Org org) {
+        try {
+            String fromEmail = APIConfig.getInstance().getConfiguration().getString(APIConfig.NEW_USER_ALERT_EMAIL);
+            String date = new SimpleDateFormat("EEE MMM d HH:mm:ss z yyyy").format(new Date());
+            String alertTopic = APIConfig.getInstance().getConfiguration().getString(APIConfig.EMAIL_ALERT_TOPIC,
+                    "iweb.nics.email.alert");
+            String newRegisteredUsers = APIConfig.getInstance().getConfiguration().getString(APIConfig.NEW_REGISTERED_USER_EMAIL);
+            String hostname = InetAddress.getLocalHost().getHostName();
+            List<String>  disList = orgDao.getOrgAdmins(org.getOrgId());
+            String toEmails = disList.toString().substring(1, disList.toString().length() - 1) + ", " + newRegisteredUsers;
+
+            if(disList.size() > 0 && !fromEmail.isEmpty()){
+                JsonEmail email = new JsonEmail(fromEmail,toEmails,
+                        "Alert from RegisterAccount@" + hostname);
+                email.setBody(date + "\n\n" + "A new user has registered: " + user.getUsername() + "\n" +
+                        "Name: " + user.getFirstname() + " " + user.getLastname() + "\n" +
+                        "Organization: " + org.getName() + "\n" +
+                        "Email: " + user.getUsername() + "\n" +
+                        "Other Information: " + registerUser.getOtherInfo());
+
+                notifyNewUserEmail(email.toJsonObject().toString(),alertTopic);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            APILogger.getInstance().e(CNAME,"Failed to send new User email alerts");
+        }
+    }
+
+    private void notifyFailedRegistration(RegisterUser registerUser, User user, Org org) {
+        try {
+            String fromEmail = APIConfig.getInstance().getConfiguration().getString(APIConfig.NEW_USER_ALERT_EMAIL);
+            String date = new SimpleDateFormat("EEE MMM d HH:mm:ss z yyyy").format(new Date());
+            String alertTopic = APIConfig.getInstance().getConfiguration().getString(APIConfig.EMAIL_ALERT_TOPIC,
+                    "iweb.nics.email.alert");
+            String sysAdmins = APIConfig.getInstance().getConfiguration()
+                    .getString(APIConfig.SYSTEM_ADMIN_ALERT_EMAILS, "");
+            String hostname = InetAddress.getLocalHost().getHostName();
+            //List<String>  disList = orgDao.getOrgAdmins(org.getOrgId());
+            //String toEmails = disList.toString().substring(1, disList.toString().length() - 1) + ", " + sysAdmins;
+            String toEmails = sysAdmins;
+
+            //if(disList.size() > 0 && !fromEmail.isEmpty()){
+            if(!sysAdmins.isEmpty()) {
+                JsonEmail email = new JsonEmail(fromEmail, toEmails,
+                        "Alert from RegisterAccount@" + hostname);
+                email.setBody(date + "\n\n" + "A new user has attempted to register" +
+                        ". However, their system user failed to successfully persist, so before" +
+                        " they can try to register again with the same email address, their" +
+                        " Identity user will need deleted in OpenAM.\n\n" +
+                        "Name: " + user.getFirstname() + " " + user.getLastname() + "\n" +
+                        "Organization: " + org.getName() + "\n" +
+                        "Email: " + user.getUsername() + "\n" +
+                        "Other Information: " + registerUser.getOtherInfo());
+
+                notifyNewUserEmail(email.toJsonObject().toString(),alertTopic);
+            }
+
+        } catch (Exception e) {
+            APILogger.getInstance().e(CNAME,"Failed to send registration failed email to Org Admins and System Admins");
+        }
+    }
 	
 	/**
 	 * Creates UserOrgWorkspace SADisplayMessageEntity objects

--- a/api-rest-service/src/test/java/edu/mit/ll/em/api/openam/OpenAmGatewayTest.java
+++ b/api-rest-service/src/test/java/edu/mit/ll/em/api/openam/OpenAmGatewayTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2008-2016, Massachusetts Institute of Technology (MIT)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package edu.mit.ll.em.api.openam;
+
+import edu.mit.ll.em.api.rs.RegisterUser;
+import edu.mit.ll.nics.common.entity.User;
+import edu.mit.ll.nics.sso.util.SSOUtil;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("FieldCanBeLocal")
+public class OpenAmGatewayTest {
+
+    private SSOUtil ssoUtil;
+    private OpenAmGateway gateway;
+    private User user;
+    private RegisterUser registerUser;
+
+    @Before
+    public void setUp() throws Exception {
+        ssoUtil = mock(SSOUtil.class);
+        gateway = new OpenAmGateway(ssoUtil);
+        user = new User();
+        user.setUsername("tester@tabordasolutions.net");
+        user.setFirstname("Test");
+        user.setLastname("Testerson");
+        registerUser = new RegisterUser();
+        registerUser.setPassword("password1");
+    }
+
+    @Test
+    public void testCreateIdentityUser() throws Exception {
+        when(ssoUtil.loginAsAdmin()).thenReturn(true);
+        when(ssoUtil.createUser(
+                "tester@tabordasolutions.net",
+                "password1",
+                "Test",
+                "Testerson",
+                false)
+        ).thenReturn("{\"status\":\"success\", \"message\":\" successfully created identity for tester@tabordasolutions.net\"}");
+
+        JSONObject response = gateway.createIdentityUser(user, registerUser);
+        assertEquals("success", response.getString("status"));
+    }
+
+    @Test
+    public void testCreateIdentityUserFailure() throws Exception {
+        when(ssoUtil.loginAsAdmin()).thenReturn(true);
+        when(ssoUtil.createUser("tester@tabordasolutions.net", "password1", "Test", "Testerson", false))
+                .thenReturn("{\"status\":\"fail\", \"message\":\"badness\"}");
+
+        JSONObject response = gateway.createIdentityUser(user, registerUser);
+        assertEquals("fail", response.getString("status"));
+        assertEquals("badness", response.getString("message"));
+    }
+
+    @Test
+    public void testCreateIdentityUserFailsWithOpenAmLoginFailure() throws Exception {
+        when(ssoUtil.loginAsAdmin()).thenReturn(false);
+        JSONObject response = gateway.createIdentityUser(user, registerUser);
+        assertEquals("fail", response.getString("status"));
+        assertEquals("Failed to log in as Administrator with SSOUtil. Cannot create Identity.", response.getString("message"));
+    }
+
+    @Test
+    public void testCreateUserFailsWithInvalidResponseFromOpenAm() throws Exception {
+        String uid = "tester@tabordasolutions.net";
+        when(ssoUtil.loginAsAdmin()).thenReturn(true);
+        when(ssoUtil.createUser("tester@tabordasolutions.net", "password1", "Test", "Testerson", false))
+                    .thenReturn("badness");
+        JSONObject response = gateway.createIdentityUser(user, registerUser);
+        assertEquals("fail", response.getString("status"));
+        assertTrue(response.getString("message").startsWith("JSON exception reading create identity response"));
+    }
+
+    @Test
+    public void testDeleteIdentityUserFailure() throws Exception {
+        String uid = "tester@tabordasolutions.net";
+        when(ssoUtil.loginAsAdmin()).thenReturn(true);
+        when(ssoUtil.deleteUser(uid))
+                .thenReturn("{\"status\":\"fail\", \"message\":\"Can't find user by uid\"}");
+
+        JSONObject response = gateway.deleteIdentityUser(uid);
+        assertEquals("fail", response.getString("status"));
+        assertEquals("Can't find user by uid", response.getString("message"));
+    }
+
+    @Test
+    public void testDeleteIdentityUser() throws Exception {
+        String uid = "tester@tabordasolutions.net";
+        when(ssoUtil.loginAsAdmin()).thenReturn(true);
+        when(ssoUtil.deleteUser(uid))
+                .thenReturn("{\"status\":\"success\", \"message\":\"successfully deleted identity with uid : " + uid + "\"}");
+        JSONObject response = gateway.deleteIdentityUser(uid);
+        assertEquals("success", response.getString("status"));
+        assertEquals("successfully deleted identity with uid : " + uid, response.getString("message"));
+    }
+
+    @Test
+    public void testDeleteUserFailsWithOpenAmLoginFailure() throws Exception {
+        String uid = "tester@tabordasolutions.net";
+        when(ssoUtil.loginAsAdmin()).thenReturn(false);
+        JSONObject response = gateway.deleteIdentityUser(uid);
+        assertEquals("fail", response.getString("status"));
+        assertEquals("Failed to log in as Administrator with SSOUtil. Cannot create Identity.", response.getString("message"));
+    }
+
+    @Test
+    public void testDeleteUserFailsWithInvalidResponseFromOpenAm() throws Exception {
+        String uid = "tester@tabordasolutions.net";
+        when(ssoUtil.loginAsAdmin()).thenReturn(true);
+        when(ssoUtil.deleteUser(uid)).thenReturn("Error");
+        JSONObject response = gateway.deleteIdentityUser(uid);
+        assertEquals("fail", response.getString("status"));
+        assertTrue(response.getString("message").startsWith("JSON exception reading delete identity response"));
+    }
+}

--- a/api-rest-service/src/test/java/edu/mit/ll/em/api/openam/OpenAmGatewayTest.java
+++ b/api-rest-service/src/test/java/edu/mit/ll/em/api/openam/OpenAmGatewayTest.java
@@ -102,7 +102,7 @@ public class OpenAmGatewayTest {
                     .thenReturn("badness");
         JSONObject response = gateway.createIdentityUser(user, registerUser);
         assertEquals("fail", response.getString("status"));
-        assertTrue(response.getString("message").startsWith("JSON exception reading create identity response"));
+        assertTrue(response.getString("message").startsWith("JSON exception reading createUser response"));
     }
 
     @Test
@@ -134,7 +134,7 @@ public class OpenAmGatewayTest {
         when(ssoUtil.loginAsAdmin()).thenReturn(false);
         JSONObject response = gateway.deleteIdentityUser(uid);
         assertEquals("fail", response.getString("status"));
-        assertEquals("Failed to log in as Administrator with SSOUtil. Cannot create Identity.", response.getString("message"));
+        assertEquals("Failed to log in as Administrator with SSOUtil. Cannot delete Identity with uid : " + uid, response.getString("message"));
     }
 
     @Test


### PR DESCRIPTION
# Summary
Rolls back changes in OpenAM if user registration changes in database fails to persist.

# What's New

Deletes user from OpenAM on failure to save the user to database.

# What's Changed

The changes address issue of not rolling back changes from OpenAM in case of user registration failures. Currently in production email notification is generated if user registration fails to save to DB. With new changes, in case of user registration failure, we attempt to rollback changes from OpenAM and email notification is generated if we are unable to rollback changes from OpenAM.