### PR TITLE
Fix coordinate issue

### DIFF
--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/formatter/KmlFormatter.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/formatter/KmlFormatter.java
@@ -61,7 +61,7 @@ public class KmlFormatter {
     private static final String LINEAR_RING_PATTERN = "(</LinearRing>)(\\s*)(<LinearRing>)";
     private static final String INNER_BOUNDRY_INSERT_PATTERN = "$1</innerBoundaryIs>$2<innerBoundaryIs>$3";
     private static final String ZERO_ELEVATION_TAIL_COORDIATE_SEPERATOR = ",0 ";
-    private static final String ZERO_ELEVATION_TAIL_COORDIATE_SEPERATOR_ERROR = ",0, ";
+    private static final String ZERO_ELEVATION_TAIL_COORDIATE_SEPERATOR_ERROR = ",0,";
 
     public void format(InputStream input, OutputStream output) throws IOException {
         byte[] buffer = new byte[4096];

--- a/api-rest-service/src/test/java/edu/mit/ll/em/api/formatter/KmlFormatterTest.java
+++ b/api-rest-service/src/test/java/edu/mit/ll/em/api/formatter/KmlFormatterTest.java
@@ -104,8 +104,17 @@ public class KmlFormatterTest {
     }
 
     @Test
-    public void testFixingCoordinatSeperatorsWhenElevationIs0() throws IOException {
-        String fileData = "<xml xmlns:atom><kml><Document><coordinates>-121.3597349039386,36.22929852296618,0, -121.360070172991,36.2293065739447,0, -121.3697243244982,36.22952658532377,0 -121.3697243244982,36.22952658532377,0</coordinates></Document><kml>";
+    public void testFixingCoordinatSeperatorsWhenElevationIs0AndSpaceBetweenCoordinates() throws IOException {
+        String fileData = "<xml xmlns:atom><kml><Document><coordinates>-121.3597349039386,36.22929852296618,0, -121.360070172991,36.2293065739447,0, -121.3697243244982,36.22952658532377,0, -121.3697243244982,36.22952658532377,0</coordinates></Document><kml>";
+        String fixedContent = formatter.fixCommonKmlIssues(fileData);
+
+        String expectedContent = "<xml xmlns:atom><kml><Document><coordinates>-121.3597349039386,36.22929852296618,0  -121.360070172991,36.2293065739447,0  -121.3697243244982,36.22952658532377,0  -121.3697243244982,36.22952658532377,0</coordinates></Document><kml>";
+        assertEquals("Expected content to have commas removed", expectedContent, fixedContent);
+    }
+
+    @Test
+    public void testFixingCoordinatSeperatorsWhenElevationIs0AndNoSpaceBetweenCoordinates() throws IOException {
+        String fileData = "<xml xmlns:atom><kml><Document><coordinates>-121.3597349039386,36.22929852296618,0,-121.360070172991,36.2293065739447,0,-121.3697243244982,36.22952658532377,0,-121.3697243244982,36.22952658532377,0</coordinates></Document><kml>";
         String fixedContent = formatter.fixCommonKmlIssues(fileData);
 
         String expectedContent = "<xml xmlns:atom><kml><Document><coordinates>-121.3597349039386,36.22929852296618,0 -121.360070172991,36.2293065739447,0 -121.3697243244982,36.22952658532377,0 -121.3697243244982,36.22952658532377,0</coordinates></Document><kml>";


### PR DESCRIPTION
Coordinates must be separated by a space and not a comma. Adjusted previous fix to handle files that have a comma and no space between coordinates.