### PR TITLE
Oes 766

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ release.properties
 .idea/
 config
 tomcat-config
+.DS_Store

--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/DatalayerServiceImpl.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/DatalayerServiceImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2017, Massachusetts Institute of Technology (MIT)
+ * Copyright (c) 2008-2018, Massachusetts Institute of Technology (MIT)
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,6 @@ package edu.mit.ll.em.api.rs.impl;
 
 import java.io.*;
 import java.math.BigInteger;
-import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -43,22 +42,17 @@ import java.security.DigestInputStream;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -72,6 +66,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.MultipartBody;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.forgerock.openam.utils.StringUtils;
 import org.geotools.data.FileDataStore;
 import org.geotools.data.FileDataStoreFinder;
 import org.geotools.data.simple.SimpleFeatureSource;
@@ -100,12 +95,9 @@ import edu.mit.ll.nics.nicsdao.DatalayerDAO;
 import edu.mit.ll.nics.nicsdao.DocumentDAO;
 import edu.mit.ll.nics.nicsdao.FolderDAO;
 import edu.mit.ll.nics.nicsdao.UserDAO;
-import edu.mit.ll.nics.nicsdao.impl.DatalayerDAOImpl;
-import edu.mit.ll.nics.nicsdao.impl.DocumentDAOImpl;
-import edu.mit.ll.nics.nicsdao.impl.FolderDAOImpl;
-import edu.mit.ll.nics.nicsdao.impl.UserDAOImpl;
 import edu.mit.ll.nics.nicsdao.impl.UserOrgDAOImpl;
 import edu.mit.ll.nics.nicsdao.impl.UserSessionDAOImpl;
+import org.springframework.util.CollectionUtils;
 
 /**
  * 
@@ -122,38 +114,69 @@ public class DatalayerServiceImpl implements DatalayerService {
 			"xmlns:gx=\"http://www.google.com/kml/ext/2.2\" " +
 			"xmlns:kml=\"http://www.opengis.net/kml/2.2\" " +
 			"xmlns:atom=\"http://www.w3.org/2005/Atom\">";
-	
+
 	/** A pattern that matches KML documents without a root <kml> element. */
 	private static final Pattern MALFORMED_KML_PATTERN = Pattern.compile("^\\s*<\\?xml[^>]+>\\s*<Document>", Pattern.MULTILINE);
-	
-	/** Folder DAO */
-	private static final DatalayerDAO datalayerDao = new DatalayerDAOImpl();
-	private static final FolderDAO folderDao = new FolderDAOImpl();
-	private static final DocumentDAO documentDao = new DocumentDAOImpl();
-	private static final UserDAO userDao = new UserDAOImpl();
-	private static final UserOrgDAOImpl userOrgDao = new UserOrgDAOImpl();
-	private static final UserSessionDAOImpl usersessionDao = new UserSessionDAOImpl();
-	
-	private static String fileUploadPath;
-	private static String mapserverURL;
-	private static String geoserverWorkspace;
-	private static String geoserverDatastore;
-	private static String webserverURL;
-	
-	private RabbitPubSubProducer rabbitProducer;
-	
-	private final Client jerseyClient;
 
-	public DatalayerServiceImpl() {
-		Configuration config = APIConfig.getInstance().getConfiguration();
-		fileUploadPath = config.getString(APIConfig.FILE_UPLOAD_PATH, "/opt/data/nics/upload");
-		geoserverWorkspace = config.getString(APIConfig.IMPORT_SHAPEFILE_WORKSPACE, "nics");
-		geoserverDatastore = config.getString(APIConfig.IMPORT_SHAPEFILE_STORE, "shapefiles");
-		mapserverURL = config.getString(APIConfig.EXPORT_MAPSERVER_URL);
-		webserverURL = config.getString(APIConfig.EXPORT_WEBSERVER_URL);
-		jerseyClient = ClientBuilder.newClient();
-	}
+    private Configuration emApiConfiguration;
+	private DatalayerDAO datalayerDao;
+	private FolderDAO folderDao;
+	private DocumentDAO documentDao;
+	private UserDAO userDao;
+	private UserOrgDAOImpl userOrgDao;
+	private UserSessionDAOImpl userSessionDao;
 	
+	private String fileUploadPath;
+	private String mapServerURL;
+	private String geoServerWorkspace;
+	private String geoServerDatastore;
+	private String webServerURL;
+
+	private RabbitPubSubProducer rabbitProducer;
+
+	private Client jerseyClient;
+
+    public DatalayerServiceImpl(Configuration emApiConfiguration, DatalayerDAO datalayerDao, FolderDAO folderDao, DocumentDAO documentDao, UserDAO userDao, UserOrgDAOImpl userOrgDao, UserSessionDAOImpl userSessionDao, RabbitPubSubProducer rabbitProducer, Client jerseyClient) {
+        this.emApiConfiguration = emApiConfiguration;
+        this.datalayerDao = this.datalayerDao;
+        this.folderDao = folderDao;
+        this.documentDao = documentDao;
+        this.userDao = userDao;
+        this.userOrgDao = userOrgDao;
+        this.userSessionDao = userSessionDao;
+        this.rabbitProducer = rabbitProducer;
+        this.jerseyClient = jerseyClient;
+        this.initializeConfigProperties();
+    }
+
+	private void initializeConfigProperties() {
+		fileUploadPath = emApiConfiguration.getString(APIConfig.FILE_UPLOAD_PATH, "/opt/data/nics/upload");
+		geoServerWorkspace = emApiConfiguration.getString(APIConfig.IMPORT_SHAPEFILE_WORKSPACE, "nics");
+		geoServerDatastore = emApiConfiguration.getString(APIConfig.IMPORT_SHAPEFILE_STORE, "shapefiles");
+		mapServerURL = emApiConfiguration.getString(APIConfig.EXPORT_MAPSERVER_URL);
+		webServerURL = emApiConfiguration.getString(APIConfig.EXPORT_WEBSERVER_URL);
+	}
+
+    public String getFileUploadPath() {
+        return this.fileUploadPath;
+    }
+
+    public String getGeoServerWorkspace() {
+        return this.geoServerWorkspace;
+    }
+
+    public String getGeoServerDatastore() {
+        return this.geoServerDatastore;
+    }
+
+    public String getMapServerURL() {
+        return this.mapServerURL;
+    }
+
+    public String getWebServerURL() {
+        return this.webServerURL;
+    }
+
 	@Override
 	public Response getTrackingLayers(int workspaceId) {
 		FieldMapResponse response = new FieldMapResponse();
@@ -168,7 +191,7 @@ public class DatalayerServiceImpl implements DatalayerService {
 		}
 		return Response.ok(response).status(Status.OK).build();
 	}
-	
+
 	@Override
 	public Response getDatalayers(String folderId) {
 		DatalayerServiceResponse datalayerResponse = new DatalayerServiceResponse();
@@ -196,7 +219,7 @@ public class DatalayerServiceImpl implements DatalayerService {
 		
 		return Response.ok(datalayerResponse).status(Status.OK).build();
 	}
-	
+
 	@Override
 	public Response postDatasource(String type, Datasource source) {
 		DatalayerServiceResponse datalayerResponse = new DatalayerServiceResponse();
@@ -361,7 +384,7 @@ public class DatalayerServiceImpl implements DatalayerService {
 		String layerName = batchName.concat(String.valueOf(System.currentTimeMillis()));
 		
 		//write all the uploaded files to the filesystem in a temp directory
-		Path shapesDirectory = Paths.get(fileUploadPath, "shapefiles");
+		Path shapesDirectory = Paths.get(this.getFileUploadPath(), "shapefiles");
 		Path batchDirectory = null;
 		try {
 			Files.createDirectories(shapesDirectory);
@@ -402,7 +425,7 @@ public class DatalayerServiceImpl implements DatalayerService {
 		}
 		
 		//add postgis layer to map server
-		if(!geoserver.addFeatureType(geoserverWorkspace, geoserverDatastore, layerName, "EPSG:3857")){
+		if(!geoserver.addFeatureType(this.getGeoServerWorkspace(), this.getGeoServerDatastore(), layerName, "EPSG:3857")){
 			try {
 				geoserverDao.removeFeaturesTable(layerName);
 			} catch (IOException e) { /* bury */}
@@ -422,7 +445,7 @@ public class DatalayerServiceImpl implements DatalayerService {
 		geoserver.updateLayerEnabled(layerName, true);
 
 		//create datalayer and datalayersource for our new layer 
-		int usersessionid = usersessionDao.getUserSessionid(username);
+		int usersessionid = userSessionDao.getUserSessionid(username);
 		
 		Datalayer datalayer = new Datalayer(); 
 		datalayer.setCreated(new Date());
@@ -672,56 +695,67 @@ public class DatalayerServiceImpl implements DatalayerService {
 	}
 
 	public Response getToken(String url, String username, String password){
-		return Response.ok(this.requestToken(url, username, password)).status(Status.OK).build();
+		return Response.ok(this.requestToken(url, username, password).readEntity(String.class)).build();
 	}
-	
+
 	public Response getToken(String datasourceId){
-		List<Map<String, Object>> data = datalayerDao.getAuthentication(datasourceId);
-		
-		if(data.get(0) != null){
-			String internalUrl = (String) data.get(0).get(SADisplayConstants.INTERNAL_URL);
-			String token = this.requestToken(internalUrl, 
-					(String) data.get(0).get(SADisplayConstants.USER_NAME),
-					(String) data.get(0).get(SADisplayConstants.PASSWORD)
-			);
-			if(token != null){
-				return Response.ok(token).status(Status.OK).build();
-			}
-		}
+        List<Map<String, Object>> data;
+        if(StringUtils.isBlank(datasourceId)) {
+            return Response.status(Status.BAD_REQUEST).entity("datasourceId is required to request token").build();
+        }
+        try {
+            data = datalayerDao.getAuthentication(datasourceId);
+        } catch(Exception e) {
+            logger.error("Failed to fetch authentication details from dataSource with Id : " + datasourceId);
+            return Response.serverError().entity("Failed to fetch dataSource authentication details with Id : " + datasourceId + e.getMessage()).build();
+        }
 
-		return Response.ok().status(Status.INTERNAL_SERVER_ERROR).build();
+		if(!CollectionUtils.isEmpty(data) && data.get(0) != null){
+            String internalUrl = (String) data.get(0).get(SADisplayConstants.INTERNAL_URL);
+            String generateTokenUrl  = this.buildGenerateTokenUrl(internalUrl);
+            if(generateTokenUrl == null) {
+                logger.error("Unable to construct generateToken request Url from service with internalUrl " + internalUrl);
+                return Response.serverError().entity("Unable to construct generateToken request Url from service with internalUrl : " + internalUrl).status(Status.INTERNAL_SERVER_ERROR).build();
+            }
+
+			Response response = this.requestToken(generateTokenUrl, (String) data.get(0).get(SADisplayConstants.USER_NAME), (String) data.get(0).get(SADisplayConstants.PASSWORD));
+            return response;
+		} else {
+            return Response.serverError().entity("Authentication details not found for dataSource with Id : " + datasourceId).build();
+        }
 	}
-	
-	private String requestToken(String internalUrl, String username, String password){
-		int index = internalUrl.indexOf("rest/services");
-		if(index == -1){ 
-			index = internalUrl.indexOf("services"); 
-		}
 
-		try {
-			if(index > -1){
-				StringBuffer url = new StringBuffer(internalUrl.substring(0, index));
-				url.append("tokens/generateToken?");
-				url.append("username=");
-				url.append(username);
-				url.append("&password=");
-				url.append(URLEncoder.encode(password,"UTF-8"));
-				url.append("&f=json");
+	private String buildGenerateTokenUrl(String internalUrl) {
+        if(StringUtils.isBlank(internalUrl)) {
+            return null;
+        }
+        int index = (internalUrl.indexOf("rest/services") > -1) ? internalUrl.indexOf("rest/services") : internalUrl.indexOf("services");
+        if (index == -1) {
+            return null;
+        }
+        StringBuffer generateTokenUrl = new StringBuffer(internalUrl.substring(0, index));
+        generateTokenUrl.append("tokens/generateToken");
+        return generateTokenUrl.toString();
+    }
 
-				WebTarget target = jerseyClient.target(url.toString());
-				Builder builder = target.request("json");
-				return builder.get().readEntity(String.class);
-			}
-		}
-		catch(UnsupportedEncodingException e) {
-			logger.error("Unable to encode password for token generation: ", e);
-		}
+	private Response requestToken(String generateTokenUrl, String username, String password) {
+        Map<String, String> requestParams = new HashMap<String, String>();
+        Form form = new Form();
+        form.param("username", username);
+        form.param("password", password);
+        form.param("f", "json");
 
-		
-		return null;
+        try {
+            WebTarget target = jerseyClient.target(generateTokenUrl.toString());
+            Builder builder = target.request(MediaType.APPLICATION_JSON_TYPE);
+            Response response = builder.post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE), Response.class);
+            return response;
+        } catch(Exception e){
+            logger.error("Failed to generate token from service url : " + generateTokenUrl, e);
+            return Response.serverError().entity("Unable to generate token from service url: " + generateTokenUrl + ", Error: " + e.getMessage()).build();
+        }
 	}
-		
-	
+
 	private byte[] writeAttachmentWithDigest(Attachment attachment, Path path, String digestAlgorithm) throws IOException, NoSuchAlgorithmException {
 		try(
 			InputStream is = attachment.getDataHandler().getInputStream();
@@ -812,10 +846,10 @@ public class DatalayerServiceImpl implements DatalayerService {
 	}
 	
 	private String getMapserverDatasourceId() {
-		if(mapserverURL == null) {
+		if(this.getMapServerURL() == null) {
 			return null;
 		}
-		String wmsMapserverURL = mapserverURL.concat("/wms");
+		String wmsMapserverURL = this.getMapServerURL().concat("/wms");
 		
 		String datasourceId = datalayerDao.getDatasourceId(wmsMapserverURL);
 		if (datasourceId == null) {
@@ -832,10 +866,10 @@ public class DatalayerServiceImpl implements DatalayerService {
 	}
 	
 	private String getFileDatasourceId(String fileExt) {
-		if(webserverURL == null) {
+		if(this.getWebServerURL() == null) {
 			return null;
 		}
-		String webServerURL = webserverURL.concat("/" + fileExt + "/");
+		String webServerURL = this.getWebServerURL().concat("/" + fileExt + "/");
 		
 		String datasourceId = datalayerDao.getDatasourceId(webServerURL);
 		if (datasourceId == null) {
@@ -916,7 +950,7 @@ public class DatalayerServiceImpl implements DatalayerService {
 		}
 		return rabbitProducer;
 	}
-	
+
 	private Response getInvalidResponse(){
 		return Response.status(Status.BAD_REQUEST).entity(
 				Status.FORBIDDEN.getReasonPhrase()).build();

--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/DatalayerServiceImpl.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/DatalayerServiceImpl.java
@@ -138,7 +138,7 @@ public class DatalayerServiceImpl implements DatalayerService {
 
     public DatalayerServiceImpl(Configuration emApiConfiguration, DatalayerDAO datalayerDao, FolderDAO folderDao, DocumentDAO documentDao, UserDAO userDao, UserOrgDAOImpl userOrgDao, UserSessionDAOImpl userSessionDao, RabbitPubSubProducer rabbitProducer, Client jerseyClient) {
         this.emApiConfiguration = emApiConfiguration;
-        this.datalayerDao = this.datalayerDao;
+        this.datalayerDao = datalayerDao;
         this.folderDao = folderDao;
         this.documentDao = documentDao;
         this.userDao = userDao;

--- a/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/DatalayerServiceImpl.java
+++ b/api-rest-service/src/main/java/edu/mit/ll/em/api/rs/impl/DatalayerServiceImpl.java
@@ -711,14 +711,7 @@ public class DatalayerServiceImpl implements DatalayerService {
         }
 
 		if(!CollectionUtils.isEmpty(data) && data.get(0) != null){
-            String internalUrl = (String) data.get(0).get(SADisplayConstants.INTERNAL_URL);
-            String generateTokenUrl  = this.buildGenerateTokenUrl(internalUrl);
-            if(generateTokenUrl == null) {
-                logger.error("Unable to construct generateToken request Url from service with internalUrl " + internalUrl);
-                return Response.serverError().entity("Unable to construct generateToken request Url from service with internalUrl : " + internalUrl).status(Status.INTERNAL_SERVER_ERROR).build();
-            }
-
-			Response response = this.requestToken(generateTokenUrl, (String) data.get(0).get(SADisplayConstants.USER_NAME), (String) data.get(0).get(SADisplayConstants.PASSWORD));
+			Response response = this.requestToken((String) data.get(0).get(SADisplayConstants.INTERNAL_URL), (String) data.get(0).get(SADisplayConstants.USER_NAME), (String) data.get(0).get(SADisplayConstants.PASSWORD));
             return response;
 		} else {
             return Response.serverError().entity("Authentication details not found for dataSource with Id : " + datasourceId).build();
@@ -738,7 +731,13 @@ public class DatalayerServiceImpl implements DatalayerService {
         return generateTokenUrl.toString();
     }
 
-	private Response requestToken(String generateTokenUrl, String username, String password) {
+	private Response requestToken(String internalUrl, String username, String password) {
+        String generateTokenUrl  = this.buildGenerateTokenUrl(internalUrl);
+        if(generateTokenUrl == null) {
+            logger.error("Unable to construct generateToken request Url from service with internalUrl " + internalUrl);
+            return Response.serverError().entity("Unable to construct generateToken request Url from service with internalUrl : " + internalUrl).status(Status.INTERNAL_SERVER_ERROR).build();
+        }
+
         Map<String, String> requestParams = new HashMap<String, String>();
         Form form = new Form();
         form.param("username", username);

--- a/api-rest-service/src/main/resources/cxf-rest-service.xml
+++ b/api-rest-service/src/main/resources/cxf-rest-service.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2008-2016, Massachusetts Institute of Technology (MIT)
+    Copyright (c) 2008-2018, Massachusetts Institute of Technology (MIT)
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
@@ -68,7 +68,17 @@
 			<bean class="edu.mit.ll.em.api.rs.impl.AnnouncementServiceImpl" />
 			<bean class="edu.mit.ll.em.api.rs.impl.CollabServiceImpl" />
 			<bean class="edu.mit.ll.em.api.rs.impl.DatalayerExportImpl" />
-			<bean class="edu.mit.ll.em.api.rs.impl.DatalayerServiceImpl" />
+			<bean class="edu.mit.ll.em.api.rs.impl.DatalayerServiceImpl" >
+				<constructor-arg ref="emApiConfiguration" />
+                <constructor-arg ref="datalayerDao" />
+                <constructor-arg ref="folderDao" />
+                <constructor-arg ref="documentDao" />
+                <constructor-arg ref="userDao" />
+                <constructor-arg ref="userOrgDao" />
+                <constructor-arg ref="userSessionDao" />
+                <constructor-arg ref="rabbitProducer" />
+                <constructor-arg ref="jerseyClient" />
+			</bean>
 			<!-- <bean class="edu.mit.ll.em.api.rs.impl.DatalayerBreadCrumbsImpl" /> -->
 			<bean class="edu.mit.ll.em.api.rs.impl.FeatureServiceImpl" />
 			<bean class="edu.mit.ll.em.api.rs.impl.FolderServiceImpl" />

--- a/api-rest-service/src/test/java/edu/mit/ll/em/api/rs/impl/DatalayerServiceImplTest.java
+++ b/api-rest-service/src/test/java/edu/mit/ll/em/api/rs/impl/DatalayerServiceImplTest.java
@@ -27,11 +27,8 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package edu.mit.ll.em.api.service;
+package edu.mit.ll.em.api.rs.impl;
 
-import edu.mit.ll.em.api.openam.OpenAmGateway;
-import edu.mit.ll.em.api.openam.OpenAmGatewayFactory;
-import edu.mit.ll.em.api.rs.impl.DatalayerServiceImpl;
 import edu.mit.ll.nics.common.constants.SADisplayConstants;
 import edu.mit.ll.nics.common.rabbitmq.RabbitPubSubProducer;
 import edu.mit.ll.nics.nicsdao.DatalayerDAO;
@@ -41,6 +38,8 @@ import edu.mit.ll.nics.nicsdao.impl.*;
 import org.apache.commons.configuration.Configuration;
 import org.glassfish.jersey.client.JerseyClient;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -184,6 +183,16 @@ public class DatalayerServiceImplTest {
         Response response = datalayerService.getToken(dataSourceId);
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
         assertEquals("Unable to generate token from service url: " + generateTokenUrl + ", Error: " + exception.getMessage(), response.getEntity());
+    }
+
+    @Test
+    public void getTokenReturnsTokenSuccessfullyGivenValidAuthDetails() {
+        Response responseExpected = Response.ok("{\"token\":\"xyz\"}").build();
+        when(builder.post(any(Entity.class), eq(Response.class))).thenReturn(responseExpected);
+
+        Response response = datalayerService.getToken(internalUrl, username, password);
+        assertEquals(responseExpected.getStatus(), response.getStatus());
+        assertEquals(responseExpected.readEntity(String.class), response.readEntity(String.class));
     }
 
     @After

--- a/api-rest-service/src/test/java/edu/mit/ll/em/api/service/DatalayerServiceImplTest.java
+++ b/api-rest-service/src/test/java/edu/mit/ll/em/api/service/DatalayerServiceImplTest.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2008-2018, Massachusetts Institute of Technology (MIT)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package edu.mit.ll.em.api.service;
+
+import edu.mit.ll.em.api.openam.OpenAmGateway;
+import edu.mit.ll.em.api.openam.OpenAmGatewayFactory;
+import edu.mit.ll.em.api.rs.impl.DatalayerServiceImpl;
+import edu.mit.ll.nics.common.constants.SADisplayConstants;
+import edu.mit.ll.nics.common.rabbitmq.RabbitPubSubProducer;
+import edu.mit.ll.nics.nicsdao.DatalayerDAO;
+import edu.mit.ll.nics.nicsdao.DocumentDAO;
+import edu.mit.ll.nics.nicsdao.FolderDAO;
+import edu.mit.ll.nics.nicsdao.impl.*;
+import org.apache.commons.configuration.Configuration;
+import org.glassfish.jersey.client.JerseyClient;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.glassfish.jersey.client.JerseyInvocation;
+import org.glassfish.jersey.client.JerseyWebTarget;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DatalayerServiceImplTest {
+    private static Configuration configuration = mock(Configuration.class);
+    private static JerseyClient jerseyClient = mock(JerseyClient.class);
+    private static DatalayerDAO datalayerDao = mock(DatalayerDAO.class);
+    private static FolderDAO folderDao = mock(FolderDAO.class);
+    private static DocumentDAO documentDao = mock(DocumentDAO.class);
+    private static UserDAOImpl userDao = mock(UserDAOImpl.class);
+    private static UserOrgDAOImpl userOrgDao = mock(UserOrgDAOImpl.class);
+    private static UserSessionDAOImpl userSessionDao = mock(UserSessionDAOImpl.class);
+    private static RabbitPubSubProducer rabbitProducer = mock(RabbitPubSubProducer.class);
+    private static DatalayerServiceImpl datalayerService = new DatalayerServiceImpl(configuration, datalayerDao, folderDao, documentDao, userDao, userOrgDao, userSessionDao, rabbitProducer, jerseyClient);
+    private static JerseyWebTarget target = mock(JerseyWebTarget.class);
+    private static JerseyInvocation.Builder builder = mock(JerseyInvocation.Builder.class);
+    private String internalUrl = "https://apps.intterragroup.com/arcgis/rest/services/NICS/SCCFDAVLResources/MapServer/0";
+    private String username = "username";
+    private String password = "password";
+    private String dataSourceId = "dataSourceId1";
+    private List<Map<String, Object>> authData = new ArrayList<Map<String, Object>>();
+
+    @Before
+    public void setup() {
+        HashMap<String, Object> authMap = new HashMap<String, Object>();
+        authMap.put(SADisplayConstants.INTERNAL_URL, internalUrl);
+        authMap.put(SADisplayConstants.USER_NAME, username);
+        authMap.put(SADisplayConstants.PASSWORD, password);
+        authData.add(authMap);
+
+        when(jerseyClient.target( anyString() )).thenReturn(target);
+        when(target.request(MediaType.APPLICATION_JSON_TYPE)).thenReturn(builder);
+        when(datalayerDao.getAuthentication(dataSourceId)).thenReturn(authData);
+    }
+
+    @Test
+    public void getTokenReturnsBadRequestGivenEmptyDataSourceId() {
+        Response response = datalayerService.getToken(null);
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("datasourceId is required to request token", response.readEntity(String.class));
+    }
+
+    @Test
+    public void getTokenReturnsResponseWithErrorDetailsGivenServiceUrlInUnexpectedFormat() {
+        String invalidInternalurl = "http://something.not.expected.com";
+        authData.get(0).put(SADisplayConstants.INTERNAL_URL, invalidInternalurl);
+        Response responseExpected = Response.ok("Unable to construct generateToken request Url from service with internalUrl " + invalidInternalurl).status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()).build();
+        when(datalayerDao.getAuthentication(dataSourceId)).thenReturn(authData);
+
+        Response response = datalayerService.getToken(dataSourceId);
+        assertEquals(responseExpected.getStatus(), response.getStatus());
+        assertEquals("Unable to construct generateToken request Url from service with internalUrl : " + invalidInternalurl, response.readEntity(String.class));
+    }
+
+    @Test
+    public void getTokenReturnsValidResponseWithToken() {
+        Response responseExpected = Response.ok("{\"token\":\"xyz\"}").build();
+        when(builder.post(any(Entity.class), eq(Response.class))).thenReturn(responseExpected);
+
+        Response response = datalayerService.getToken(dataSourceId);
+        assertEquals(responseExpected.getStatus(), response.getStatus());
+        assertEquals(responseExpected.readEntity(String.class), response.readEntity(String.class));
+    }
+
+    @Test
+    public void getTokenReturnsResponseWithErrorDetailsOnFailingToGetCredentialsFromDB() {
+        Response responseExpected = Response.ok("Invalid credentials").status(401).build();
+        Exception exception = new RuntimeException("test exception");
+        when(datalayerDao.getAuthentication(dataSourceId)).thenThrow(exception);
+
+        Response response = datalayerService.getToken(dataSourceId);
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+        assertTrue(response.readEntity(String.class).contains("Failed to fetch dataSource authentication details with Id : " + dataSourceId));
+        assertTrue(response.readEntity(String.class).contains(exception.getMessage()));
+    }
+
+    @Test
+    public void getTokenReturnsResponseWithErrorDetailsWhenAuthenticationDetailsAreNotFoundInDB() {
+        Response responseExpected = Response.ok("Invalid credentials").status(401).build();
+        Mockito.reset(datalayerDao);
+        when(datalayerDao.getAuthentication(dataSourceId)).thenReturn(null);
+
+        Response response = datalayerService.getToken(dataSourceId);
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+        assertEquals("Authentication details not found for dataSource with Id : " + dataSourceId, response.getEntity());
+
+        when(datalayerDao.getAuthentication(dataSourceId)).thenReturn(new ArrayList<Map<String, Object>>());
+        response = datalayerService.getToken(dataSourceId);
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+        assertEquals("Authentication details not found for dataSource with Id : " + dataSourceId, response.getEntity());
+
+        List<Map<String, Object>> authDetailsFromDB = new ArrayList<Map<String,Object>>();
+        authDetailsFromDB.add(null);
+        when(datalayerDao.getAuthentication(dataSourceId)).thenReturn(authDetailsFromDB);
+        response = datalayerService.getToken(dataSourceId);
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+        assertEquals("Authentication details not found for dataSource with Id : " + dataSourceId, response.getEntity());
+    }
+
+    @Test
+    public void getTokenReturnsResponseWithErrorDetailsOnFailingToGetTokenFromTokenService() {
+        Response responseExpected = Response.ok("Invalid credentials").status(401).build();
+        when(builder.post(any(Entity.class), eq(Response.class))).thenReturn(responseExpected);
+
+        Response response = datalayerService.getToken(dataSourceId);
+        assertEquals(responseExpected.getStatus(), response.getStatus());
+        assertEquals(responseExpected.readEntity(String.class), response.readEntity(String.class));
+    }
+
+    @Test
+    public void getTokenReturnsResponseWithErrorDetailsWhenTokenServiceThrowsException() {
+        int index = (internalUrl.indexOf("rest/services") > -1) ? internalUrl.indexOf("rest/services") : internalUrl.indexOf("services");
+        String generateTokenUrl = internalUrl.substring(0, index) + "tokens/generateToken";
+        Response responseExpected = Response.ok("Invalid credentials").status(401).build();
+        Exception exception = new RuntimeException("test exception");
+        when(builder.post(any(Entity.class), eq(Response.class))).thenThrow(exception);
+
+        Response response = datalayerService.getToken(dataSourceId);
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+        assertEquals("Unable to generate token from service url: " + generateTokenUrl + ", Error: " + exception.getMessage(), response.getEntity());
+    }
+
+    @After
+    public void tearDown() {
+        Mockito.reset(configuration, datalayerDao, folderDao, documentDao, userDao, userOrgDao, userSessionDao, rabbitProducer, jerseyClient, target, builder);
+    }
+}


### PR DESCRIPTION
#What is changed
Few ArcGISRest datasources are failing to import into SCOUT. It has been root caused to making use of GET request on generateToken request.  POST method on generateToken is enabled on all ESRI services but GET is not. Hence, DatalayerServiceImpl.getToken() is updated to make use of POST instead of GET get Token from ESRI service.
Added unit tests.